### PR TITLE
Fix for western-hemisphere extent issue that has CDS report extents f…

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -326,6 +326,14 @@ if(SingularDL){ # If user forced download to happen in one
     Era5_ras <- stack(Era5_ls)
   }
 
+  ## Fix for extent of some variables like evaporation_from_vegetation_transpiration for which the x-extent values come out weirdly despite the correct data being downloaded
+  MaxOffset <- max(abs(round(as.vector(extent(Era5_ras))-c(Extent[2], Extent[4], Extent[3], Extent[1]), 2))) # identify whether there is an issue (currently, we only know of cases where western-hemisphere data is reported as x-extents that are 360-x-Extent values)
+  if(MaxOffset > 270){
+    DataOffset <- min(abs(round(as.vector(extent(Era5_ras))-c(Extent[2], Extent[4], Extent[3], Extent[1]), 2))) # identify by how much grid had to be expanded for download
+    extent(Era5_ras) <- extent(Extent[2]-DataOffset, Extent[4]+DataOffset,
+                               Extent[3]-DataOffset, Extent[1]+DataOffset) # the extent the object should have assigned to the object
+  }
+
   ### SingularDL limiting of data to original time-series requirements
   ## time-sequence of requested download by user
   if(TResolution == "day" | TResolution == "hour"){


### PR DESCRIPTION
…or some variables in the western hemisphere reported as 360-abs(queried extent)

This is a fix for the problem with CDS products highlighted in #12 .

I have submitted a ticket to ECMWF to make them aware of this issue and hopefully resolve it server-side. Until then (as well as thereafter), the fix introduced here should lead to expected extents being reported.