### PR TITLE
Fix Error in using KrigR #17

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,5 @@ Depends:
     sf,
     fasterize,
     stars,
-    httr
+    httr,
+    terra

--- a/R/Kriging.R
+++ b/R/Kriging.R
@@ -93,7 +93,7 @@
 #' }
 #'
 #' @export
-krigR <- function(Data = NULL, Covariates_coarse = NULL, Covariates_fine = NULL, KrigingEquation = "ERA ~ DEM", Cores = detectCores(), Dir = getwd(), FileName, Keep_Temporary = TRUE, SingularTry = 10, Variable, PrecipFix = FALSE, Type = "reanalysis", DataSet = "era5-land", DateStart, DateStop, TResolution = "month", TStep = 1, FUN = 'mean', Extent, Buffer = 0.5, ID = "ID", API_Key, API_User, Target_res, Source = "USGS", nmax = Inf,  TryDown = 10, verbose = TRUE, TimeOut = 36000, SingularDL = FALSE, SaveOutput = TRUE...){
+krigR <- function(Data = NULL, Covariates_coarse = NULL, Covariates_fine = NULL, KrigingEquation = "ERA ~ DEM", Cores = detectCores(), Dir = getwd(), FileName, Keep_Temporary = TRUE, SingularTry = 10, Variable, PrecipFix = FALSE, Type = "reanalysis", DataSet = "era5-land", DateStart, DateStop, TResolution = "month", TStep = 1, FUN = 'mean', Extent, Buffer = 0.5, ID = "ID", API_Key, API_User, Target_res, Source = "USGS", nmax = Inf,  TryDown = 10, verbose = TRUE, TimeOut = 36000, SingularDL = FALSE, SaveOutput = TRUE,...){
   ## CALL LIST (for storing how the function as called in the output) ----
   if(is.null(Data)){
     Data_Retrieval <- list(Variable = Variable,

--- a/R/Kriging.R
+++ b/R/Kriging.R
@@ -37,7 +37,6 @@
 #' @param verbose Optional, logical. Whether to report progress of data download (if queried) in the console or not.
 #' @param TimeOut Numeric. The timeout for each download in seconds. Default 36000 seconds (10 hours).
 #' @param SingularDL Logical. Whether to force download of data in one call to CDS or automatically break download requests into individual monthly downloads. Default is FALSE.
-#' @param SaveOutput Logical. Whether to save the final output in a NetCDF file. Default to TRUE.
 #' @return A list object containing the downscaled data as well as the standard error for downscaling as well as the call to the krigR function, and two NETCDF (.nc) file in the specified directory which are the two data contents of the aforementioned list. A temporary directory is populated with individual NETCDF (.nc) files throughout the runtime of krigR which is deleted upon completion if Keep_Temporary = TRUE and all layers in the Data raster object were kriged successfully.
 #' @examples
 #' \dontrun{

--- a/R/Kriging.R
+++ b/R/Kriging.R
@@ -37,6 +37,7 @@
 #' @param verbose Optional, logical. Whether to report progress of data download (if queried) in the console or not.
 #' @param TimeOut Numeric. The timeout for each download in seconds. Default 36000 seconds (10 hours).
 #' @param SingularDL Logical. Whether to force download of data in one call to CDS or automatically break download requests into individual monthly downloads. Default is FALSE.
+#' @param SaveOutput Logical. Whether to save the final output in a NetCDF file. Default to TRUE.
 #' @return A list object containing the downscaled data as well as the standard error for downscaling as well as the call to the krigR function, and two NETCDF (.nc) file in the specified directory which are the two data contents of the aforementioned list. A temporary directory is populated with individual NETCDF (.nc) files throughout the runtime of krigR which is deleted upon completion if Keep_Temporary = TRUE and all layers in the Data raster object were kriged successfully.
 #' @examples
 #' \dontrun{
@@ -272,9 +273,12 @@ krigR <- function(Data = NULL, Covariates_coarse = NULL, Covariates_fine = NULL,
   ## SAVING FINAL PRODUCT ----
   if(is.null(DataSkips)){ # Skip check: if no layers needed to be skipped
     Ras_Krig <- brick(Ras_Krig) # convert list of kriged layers in actual rasterbrick of kriged layers
-    writeRaster(x = Ras_Krig, filename = file.path(Dir, FileName), overwrite = TRUE, format="CDF") # save final product as raster
     Ras_Var <- brick(Ras_Var) # convert list of kriged layers in actual rasterbrick of kriged layers
-    writeRaster(x = Ras_Var, filename = file.path(Dir, paste0("SE_",FileName)), overwrite = TRUE, format="CDF") # save final product as raster
+    if(SaveOutput){
+      writeRaster(x = Ras_Krig, filename = file.path(Dir, FileName), overwrite = TRUE, format="CDF") # save final product as raster
+      writeRaster(x = Ras_Var, filename = file.path(Dir, paste0("SE_",FileName)), overwrite = TRUE, format="CDF") # save final product as raster
+    }
+    
   }else{ # if some layers needed to be skipped
     warning(paste0("Some of the layers in your raster could not be kriged. You will find all the individual layers (kriged and not kriged) in ", Dir, "."))
     Keep_Temporary <- TRUE # keep temporary files so kriged products are not deleted

--- a/R/Kriging.R
+++ b/R/Kriging.R
@@ -93,7 +93,7 @@
 #' }
 #'
 #' @export
-krigR <- function(Data = NULL, Covariates_coarse = NULL, Covariates_fine = NULL, KrigingEquation = "ERA ~ DEM", Cores = detectCores(), Dir = getwd(), FileName, Keep_Temporary = TRUE, SingularTry = 10, Variable, PrecipFix = FALSE, Type = "reanalysis", DataSet = "era5-land", DateStart, DateStop, TResolution = "month", TStep = 1, FUN = 'mean', Extent, Buffer = 0.5, ID = "ID", API_Key, API_User, Target_res, Source = "USGS", nmax = Inf,  TryDown = 10, verbose = TRUE, TimeOut = 36000, SingularDL = FALSE, ...){
+krigR <- function(Data = NULL, Covariates_coarse = NULL, Covariates_fine = NULL, KrigingEquation = "ERA ~ DEM", Cores = detectCores(), Dir = getwd(), FileName, Keep_Temporary = TRUE, SingularTry = 10, Variable, PrecipFix = FALSE, Type = "reanalysis", DataSet = "era5-land", DateStart, DateStop, TResolution = "month", TStep = 1, FUN = 'mean', Extent, Buffer = 0.5, ID = "ID", API_Key, API_User, Target_res, Source = "USGS", nmax = Inf,  TryDown = 10, verbose = TRUE, TimeOut = 36000, SingularDL = FALSE, SaveOutput = TRUE...){
   ## CALL LIST (for storing how the function as called in the output) ----
   if(is.null(Data)){
     Data_Retrieval <- list(Variable = Variable,

--- a/R/Kriging.R
+++ b/R/Kriging.R
@@ -37,6 +37,7 @@
 #' @param verbose Optional, logical. Whether to report progress of data download (if queried) in the console or not.
 #' @param TimeOut Numeric. The timeout for each download in seconds. Default 36000 seconds (10 hours).
 #' @param SingularDL Logical. Whether to force download of data in one call to CDS or automatically break download requests into individual monthly downloads. Default is FALSE.
+#' @param SaveOutput Logical. Whether to save the output as a NetCDF file. Default is TRUE.
 #' @return A list object containing the downscaled data as well as the standard error for downscaling as well as the call to the krigR function, and two NETCDF (.nc) file in the specified directory which are the two data contents of the aforementioned list. A temporary directory is populated with individual NETCDF (.nc) files throughout the runtime of krigR which is deleted upon completion if Keep_Temporary = TRUE and all layers in the Data raster object were kriged successfully.
 #' @examples
 #' \dontrun{

--- a/R/download.R
+++ b/R/download.R
@@ -476,7 +476,7 @@ if(SingularDL){ # If user forced download to happen in one
   }
 
   ### SAVING DATA ----
-  writeRaster(x = Era5_ras, filename = file.path(Dir, FileName), overwrite = TRUE, format="CDF", varname = Variable)
+  terra::writeCDF(x = as(Era5_ras, "SpatRaster"), filename = paste0(file.path(Dir, FileName),".nc"), overwrite = TRUE, varname = Variable)
   unlink(Files_vec, recursive = TRUE)
   return(stack(file.path(Dir, paste0(FileName, ".nc")))) # to circumvent issues with 1-hour downloads
 }

--- a/man/krigR.Rd
+++ b/man/krigR.Rd
@@ -35,6 +35,7 @@ krigR(
   verbose = TRUE,
   TimeOut = 36000,
   SingularDL = FALSE,
+  SaveOutput = TRUE,
   ...
 )
 }
@@ -98,6 +99,8 @@ krigR(
 \item{TimeOut}{Numeric. The timeout for each download in seconds. Default 36000 seconds (10 hours).}
 
 \item{SingularDL}{Logical. Whether to force download of data in one call to CDS or automatically break download requests into individual monthly downloads. Default is FALSE.}
+
+\item{SaveOutput}{Logical. Whether to save the output as a NetCDF file. Default is TRUE}
 }
 \value{
 A list object containing the downscaled data as well as the standard error for downscaling as well as the call to the krigR function, and two NETCDF (.nc) file in the specified directory which are the two data contents of the aforementioned list. A temporary directory is populated with individual NETCDF (.nc) files throughout the runtime of krigR which is deleted upon completion if Keep_Temporary = TRUE and all layers in the Data raster object were kriged successfully.


### PR DESCRIPTION
Moving from raster::writeRaster() to  `terra::writeCDF()` solved the following error with ncdf4 package

```
Error in ncdf4::ncvar_def(varname, varunit, list(xdim, ydim, zdim), NAflag,  : 
  unused argument (sources = "C:\\Users\\fabio\\Desktop\\KrigR\\0001_2m_temperature_2020-01-01_2020-01-31_month.nc")
```

`krigR()` requires mandatory the `FileName` argument (for example "pippo.nc").