### PR TITLE
Fix for hour-level downloads shaving off first hour

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -347,7 +347,7 @@ if(SingularDL){ # If user forced download to happen in one
   }else{
     Layer_seq <- seq.Date(from = DateStart, to = DateStop, by = "month")
   }
-  if(DateStart == "1950-01-01" & TResolution == "day" | TResolution == "hour"){
+  if(DateStart == "1950-01-01" & TResolution == "day" | DateStart == "1950-01-01" & TResolution == "hour"){
     Layer_seq <- Layer_seq[-1]
   }
   ## subsetting of downloaded data

--- a/R/download.R
+++ b/R/download.R
@@ -360,7 +360,7 @@ if(SingularDL){ # If user forced download to happen in one
     }else{
       LayerDL_seq <- seq.Date(from = SingularDL_Start, to = SingularDL_Stop, by = "month")
     }
-    if(DateStart == "1950-01-01" & TResolution == "day" | TResolution == "hour"){
+    if(DateStart == "1950-01-01" & TResolution == "day"| DateStart == "1950-01-01" & TResolution == "hour"){
       LayerDL_seq <- LayerDL_seq[-1]
     }
 


### PR DESCRIPTION
This should only happen for 1950-01-01 data as some variables miss data for this layer