### PR TITLE
Update to handle zip downloads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: KrigR
 Type: Package
 Title: Downloading, Aggregating, and Kriging of ECMWF CDS-Data
-Version: 0.9.4
+Version: 0.9.5
 Authors@R: as.person(c(
     "Erik Kusch <erik@i-solution.de> [aut, cre]", 
     "Richard Davy <Richard.Davy@nersc.no> [aut]"

--- a/R/CDSAPI.R
+++ b/R/CDSAPI.R
@@ -298,7 +298,27 @@ Execute.Requests <- function(Requests_ls, Dir, API_User, API_Key, TryDown, verbo
             ),
             type = "message"
           )
+          print(Download_CDS)
           rm(Download_CDS)
+
+          ## check if file can be loaded
+          LoadTry <- tryCatch(rast(API_request$get_request()$target),
+            error = function(e) {
+              e
+            }
+          )
+          if (class(LoadTry)[1] == "simpleError") {
+            FNAME <- API_request$get_request()$target
+            file.rename(FNAME, paste0(FNAME, ".zip")) # make into zip
+            extrazip <- unzip(paste0(FNAME, ".zip"), list = TRUE)$Name # find name of file in zip
+            unzip(paste0(FNAME, ".zip"), exdir = dirname(FNAME))
+            file.rename(
+              file.path(dirname(FNAME), extrazip),
+              file.path(dirname(FNAME), basename(FNAME))
+            ) # make into zip
+            unlink(paste0(FNAME, ".zip"))
+            warning("CDS download seems to have produced a .zip file. KrigR has automatically extracted data from this file. This is currently an experimental fix.")
+          }
 
           ## purge request and check succes of doing so
           checkdeletion <- capture.output(

--- a/R/Checks.R
+++ b/R/Checks.R
@@ -78,7 +78,20 @@ Check.Krig <- function(Data, CovariatesCoarse, CovariatesFine, KrigingEquation) 
 
   ## Data Availability ===============
   DataSkips <- NULL # data layers without enough data to be skipped in kriging
-  Data_vals <- base::colSums(matrix(!is.na(terra::values(Data)), ncol = terra::nlyr(Data))) # a value of 0 indicates a layer only made of NAs
+  vals <- terra::values(Data)
+  Datavars <- apply(vals, 2, FUN = function(x) {
+    length(unique(na.omit(x)))
+  })
+  if (length(which(Datavars < 2)) > 0) {
+    if (length(which(Datavars < 2)) != terra::nlyr(Data)) {
+      stop(paste0("Layer(s) ", paste(which(Datavars == 0), collapse = ", "), " of your data do(es) not contain enough variation. Kriging cannot be performed. Usually, increasing the extent of kriging can fix this issue."))
+      DataSkips <- which(Datavars < 2)
+    } else {
+      stop("Your Data does not contain enough variation. Kriging cannot be performed. Usually, increasing the extent of kriging can fix this issue.")
+    }
+  }
+
+  Data_vals <- base::colSums(matrix(!is.na(vals), ncol = terra::nlyr(Data))) # a value of 0 indicates a layer only made of NAs
   if (length(which(Data_vals < 2)) > 0) {
     if (length(which(Data_vals < 2)) != terra::nlyr(Data)) {
       stop(paste0("Layer(s) ", paste(which(Data_vals == 0), collapse = ", "), " of your data do(es) not contain enough data. Kriging cannot be performed. Usually, increasing the extent of kriging can fix this issue."))


### PR DESCRIPTION
This addresses #93 which reported undesired .zip downloads which indicate a change in CDS API responses. Now have a small checker that resolves these issues.